### PR TITLE
Refactor Pricing & Trainee Messages to Chakra UI and fix trainer schedule import

### DIFF
--- a/gymflow-client/src/App.jsx
+++ b/gymflow-client/src/App.jsx
@@ -18,7 +18,7 @@ import TrainerDashboard from './pages/Trainer/Dashboard';
 import TrainerMessagesPage from './pages/Trainer/Messages.jsx';
 import TrainerClassesPage from './pages/Trainer/Classes.jsx';
 import TrainerStats from './pages/TrainerStats.jsx';
-import TrainerSchedulePage from './pages/trainer/TrainerSchedulePage.jsx';
+import TrainerSchedulePage from './pages/Trainer/TrainerSchedulePage.jsx';
 import AssignProgramPage from './pages/Trainer/AssignProgramPage.jsx';
 
 // Trainee Pages

--- a/gymflow-client/src/components/PricingSection.jsx
+++ b/gymflow-client/src/components/PricingSection.jsx
@@ -1,14 +1,20 @@
-// בקובץ: src/components/PricingSection.jsx
-
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Button,
+  Container,
+  Flex,
+  Heading,
+  List,
+  SimpleGrid,
+  Spinner,
+  Text,
+} from '@chakra-ui/react';
 import { useAuth } from '../hooks/useAuth';
-// === 1. שינוי הייבוא: משתמשים ב-apiService הגנרי ===
 import apiService from '../api/apiService';
-import './css/PricingSection.css';
 
 const PricingSection = () => {
-  // === 2. שינוי שם המשתנה לבהירות ===
   const [subscriptionTypes, setSubscriptionTypes] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -19,11 +25,10 @@ const PricingSection = () => {
     const fetchSubscriptionTypes = async () => {
       try {
         setLoading(true);
-        // === 3. שינוי קריאת ה-API לנתיב הנכון ===
         const types = await apiService.get('/subscriptions/types');
 
         const activeTypes = types
-          .filter(type => type.is_active)
+          .filter((type) => type.is_active)
           .sort((a, b) => a.price - b.price);
 
         setSubscriptionTypes(activeTypes);
@@ -40,57 +45,92 @@ const PricingSection = () => {
 
   const handleSelectPackage = (packageId) => {
     if (isAuthenticated) {
-      // אם מחובר, שלח לעמוד האישור (שניצור בהמשך)
       navigate(`/trainee/subscriptions/confirm/${packageId}`);
     } else {
-      // אם לא מחובר, שמור את היעד והפנה ללוגין
       setRedirectPath('/trainee/subscriptions/pricing');
       navigate('/login');
     }
   };
 
   if (loading) {
-    return <div className="pricing-section-loading">טוען חבילות...</div>;
+    return (
+      <Flex justify="center" py={12}>
+        <Spinner size="xl" color="brand.400" />
+      </Flex>
+    );
   }
 
   if (error) {
-    return <div className="pricing-section-error">{error}</div>;
+    return (
+      <Text textAlign="center" py={8} color="red.400">
+        {error}
+      </Text>
+    );
   }
 
   return (
-    <section className="pricing-section" id="pricing">
-      <h2 className="section-title">תוכניות מחיר</h2>
-      <p className="section-subtitle">בחר את החבילה המתאימה לך</p>
-      <div className="packages-grid">
-        {/* === 4. שינוי שם המשתנה בלולאה === */}
-        {subscriptionTypes.map((subType) => (
-          <div key={subType.id} className="package-card">
-            <h3>{subType.name}</h3>
-            <div className="package-price">
-              <span className="currency">₪</span>
-              <span className="amount">{parseFloat(subType.price).toFixed(0)}</span>
-              {/* === 5. התאמת שם השדה ל-duration_days === */}
-              <span className="period">/ {subType.duration_days} ימים</span>
-            </div>
-            <ul className="package-features">
-              {/* ודא שהאובייקט כולל תיאור */}
-              {(subType.description || '').split('\n').map((feature, idx) => (
-                <li key={idx}>
-                  <span className="check-icon">✓</span>
-                  {feature}
-                </li>
-              ))}
-            </ul>
-            <button
-              className="subscribe-button"
-              onClick={() => handleSelectPackage(subType.id)}
+    <Box py={20} bg="dark.section" id="pricing">
+      <Container maxW="container.xl">
+        <Heading textAlign="center" mb={4} color="brand.500" textTransform="uppercase">
+          תוכניות מחיר
+        </Heading>
+        <Text textAlign="center" color="gray.400" mb={12}>
+          בחר את החבילה המתאימה לך
+        </Text>
+
+        <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} gap={8}>
+          {subscriptionTypes.map((subType) => (
+            <Box
+              key={subType.id}
+              bg="dark.card"
+              borderRadius="2xl"
+              borderWidth="1px"
+              borderColor="dark.border"
+              p={8}
+              textAlign="right"
+              dir="rtl"
+              boxShadow="xl"
+              transition="all 0.2s"
+              _hover={{ transform: 'translateY(-6px)', borderColor: 'brand.400' }}
             >
-              הצטרף עכשיו
-            </button>
-          </div>
-        ))}
-      </div>
-    </section>
+              <Heading size="lg" mb={6} color="brand.500">
+                {subType.name}
+              </Heading>
+
+              <Text fontSize="4xl" color="brand.400" fontWeight="bold" mb={6}>
+                ₪{parseFloat(subType.price).toFixed(0)}
+                <Text as="span" fontSize="md" color="gray.400" fontWeight="normal">
+                  {' '}/ {subType.duration_days} ימים
+                </Text>
+              </Text>
+
+              <List.Root gap={3} mb={8}>
+                {(subType.description || '')
+                  .split('\n')
+                  .filter(Boolean)
+                  .map((feature, idx) => (
+                    <List.Item key={idx} display="flex" alignItems="center" color="gray.300">
+                      <Text as="span" color="brand.400" me={2}>
+                        ✓
+                      </Text>
+                      <Text>{feature}</Text>
+                    </List.Item>
+                  ))}
+              </List.Root>
+
+              <Button
+                w="full"
+                colorPalette="brand"
+                size="lg"
+                onClick={() => handleSelectPackage(subType.id)}
+              >
+                הצטרף עכשיו
+              </Button>
+            </Box>
+          ))}
+        </SimpleGrid>
+      </Container>
+    </Box>
   );
 };
 

--- a/gymflow-client/src/pages/Trainee/TraineeMessagesPage.jsx
+++ b/gymflow-client/src/pages/Trainee/TraineeMessagesPage.jsx
@@ -1,7 +1,19 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  Container,
+  Flex,
+  Heading,
+  Input,
+  Spinner,
+  Stack,
+  Text,
+} from '@chakra-ui/react';
 import apiService from '../../api/apiService.js';
 import SendPrivateMessageForm from '../all/SendPrivateMessageForm.jsx';
-import '../../../styles/theme.css';
 
 const TraineeMessagesPage = () => {
   const [privateMessages, setPrivateMessages] = useState([]);
@@ -18,105 +30,151 @@ const TraineeMessagesPage = () => {
       setLoading(true);
       setError(null);
       try {
-        const privateMsgs = await apiService.get('/trainee/messages/private').catch(e => { console.error('שגיאה בהודעות פרטיות', e); throw e; });
-        const broadcastMsgs = await apiService.get('/broadcast-messages').catch(e => { console.error('שגיאה בהודעות כלליות', e); throw e; });
-        const sentMsgs = await apiService.get('/messages/sent-private').catch(e => { console.error('שגיאה בהודעות פרטיות שנשלחו', e); throw e; });
+        const privateMsgs = await apiService.get('/trainee/messages/private');
+        const broadcastMsgs = await apiService.get('/broadcast-messages');
+        const sentMsgs = await apiService.get('/messages/sent-private');
+
         setPrivateMessages(privateMsgs);
         setBroadcastMessages(broadcastMsgs);
         setSentPrivateMessages(sentMsgs);
       } catch (err) {
+        console.error('Error fetching trainee messages:', err);
         setError('שגיאה בטעינת הודעות');
       } finally {
         setLoading(false);
       }
     };
+
     fetchMessages();
   }, []);
 
+  const filteredAndSortedSentMessages = useMemo(() => (
+    sentPrivateMessages
+      .filter((msg) => {
+        const name = (msg.receiver_name || msg.receiver_email || '').toLowerCase();
+        return name.includes(sentFilter.toLowerCase());
+      })
+      .sort((a, b) => {
+        const aName = (a.receiver_name || a.receiver_email || '').toLowerCase();
+        const bName = (b.receiver_name || b.receiver_email || '').toLowerCase();
+        if (aName < bName) return sentSortAsc ? -1 : 1;
+        if (aName > bName) return sentSortAsc ? 1 : -1;
+        return 0;
+      })
+  ), [sentPrivateMessages, sentFilter, sentSortAsc]);
+
+  const tabConfig = [
+    { key: 'broadcast', label: 'הודעות כלליות' },
+    { key: 'private', label: 'הודעות פרטיות' },
+    { key: 'sent', label: 'הודעות שנשלחו' },
+  ];
+
   return (
-    <div className="trainer-messages-container">
-      <h2>ההודעות שלי</h2>
-      <div className="tabs">
-        <button className={`tab-btn${selectedTab === 'broadcast' ? ' selected' : ''}`} onClick={() => setSelectedTab('broadcast')}>הודעות כלליות</button>
-        <button className={`tab-btn${selectedTab === 'private' ? ' selected' : ''}`} onClick={() => setSelectedTab('private')}>הודעות פרטיות</button>
-        <button className={`tab-btn${selectedTab === 'sent' ? ' selected' : ''}`} onClick={() => setSelectedTab('sent')}>הודעות שנשלחו</button>
-      </div>
-      <div className="card-section">
-        <div style={{ margin: '24px 0' }}>
-          <SendPrivateMessageForm />
-        </div>
-        {loading && <div style={{ textAlign: 'center', marginTop: 40 }}>טוען...</div>}
-        {error && <div className="toast-error">{error}</div>}
-        {!loading && !error && privateMessages.length === 0 && broadcastMessages.length === 0 && <div>לא נמצאו הודעות.</div>}
-        {selectedTab === 'broadcast' && (
-          <div style={{ marginBottom: 32 }}>
-            <h3 className="section-title">הודעות כלליות</h3>
-            <ul style={{ listStyle: 'none', padding: 0 }}>
+    <Container maxW="container.lg" py={10}>
+      <Heading mb={6} color="brand.500">ההודעות שלי</Heading>
+
+      <Stack direction={{ base: 'column', md: 'row' }} gap={3} mb={6}>
+        {tabConfig.map((tab) => (
+          <Button
+            key={tab.key}
+            onClick={() => setSelectedTab(tab.key)}
+            variant={selectedTab === tab.key ? 'solid' : 'outline'}
+            colorPalette="brand"
+          >
+            {tab.label}
+          </Button>
+        ))}
+      </Stack>
+
+      <Card.Root bg="dark.card" borderColor="dark.border" borderWidth="1px">
+        <Card.Body>
+          <Box mb={6}>
+            <SendPrivateMessageForm />
+          </Box>
+
+          {loading && (
+            <Flex justify="center" py={8}>
+              <Spinner size="lg" color="brand.400" />
+            </Flex>
+          )}
+
+          {error && (
+            <Alert.Root status="error" mb={4}>
+              <Alert.Title>{error}</Alert.Title>
+            </Alert.Root>
+          )}
+
+          {!loading && !error && privateMessages.length === 0 && broadcastMessages.length === 0 && (
+            <Text>לא נמצאו הודעות.</Text>
+          )}
+
+          {selectedTab === 'broadcast' && !loading && (
+            <Stack gap={4}>
+              <Heading size="md" color="brand.400">הודעות כלליות</Heading>
               {broadcastMessages.map((msg, idx) => (
-                <li key={msg.id || idx} className="card" style={{ marginBottom: 18 }}>
-                  <div className="class-name">{msg.message_text.split('\n')[0]}</div>
-                  <div style={{ color: 'var(--text-muted)', marginBottom: 4 }}>{msg.message_text.split('\n').slice(1).join(' ')}</div>
-                  <div style={{ fontSize: 12, color: 'var(--accent-color)' }}>{msg.sent_at ? new Date(msg.sent_at).toLocaleString('he-IL') : ''}</div>
-                </li>
+                <Card.Root key={msg.id || idx} bg="dark.bg" borderColor="dark.border" borderWidth="1px">
+                  <Card.Body>
+                    <Text fontWeight="bold" mb={1}>{msg.message_text.split('\n')[0]}</Text>
+                    <Text color="gray.400" mb={1}>{msg.message_text.split('\n').slice(1).join(' ')}</Text>
+                    <Text fontSize="sm" color="brand.400">
+                      {msg.sent_at ? new Date(msg.sent_at).toLocaleString('he-IL') : ''}
+                    </Text>
+                  </Card.Body>
+                </Card.Root>
               ))}
-            </ul>
-          </div>
-        )}
-        {selectedTab === 'private' && (
-          <div>
-            <h3 className="section-title">הודעות פרטיות</h3>
-            <ul style={{ listStyle: 'none', padding: 0 }}>
+            </Stack>
+          )}
+
+          {selectedTab === 'private' && !loading && (
+            <Stack gap={4}>
+              <Heading size="md" color="brand.400">הודעות פרטיות</Heading>
               {privateMessages.map((msg, idx) => (
-                <li key={msg.id || idx} className="card" style={{ marginBottom: 18 }}>
-                  <div className="class-name">מאת: {msg.sender_name || msg.sender_email || 'משתמש'}</div>
-                  <div style={{ color: 'var(--text-muted)', marginBottom: 4 }}>{msg.message_text}</div>
-                  <div style={{ fontSize: 12, color: 'var(--accent-color)' }}>{msg.sent_at ? new Date(msg.sent_at).toLocaleString('he-IL') : ''}</div>
-                </li>
+                <Card.Root key={msg.id || idx} bg="dark.bg" borderColor="dark.border" borderWidth="1px">
+                  <Card.Body>
+                    <Text fontWeight="bold" mb={1}>מאת: {msg.sender_name || msg.sender_email || 'משתמש'}</Text>
+                    <Text color="gray.400" mb={1}>{msg.message_text}</Text>
+                    <Text fontSize="sm" color="brand.400">
+                      {msg.sent_at ? new Date(msg.sent_at).toLocaleString('he-IL') : ''}
+                    </Text>
+                  </Card.Body>
+                </Card.Root>
               ))}
-            </ul>
-          </div>
-        )}
-        {selectedTab === 'sent' && (
-          <div>
-            <h3 className="section-title">הודעות פרטיות שנשלחו</h3>
-            <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
-              <input
-                type="text"
-                placeholder="סנן לפי שם/אימייל נמען..."
-                value={sentFilter}
-                onChange={e => setSentFilter(e.target.value)}
-                className="input-dark"
-                style={{ flex: 1 }}
-              />
-              <button onClick={() => setSentSortAsc(v => !v)} className="action-btn" style={{ padding: '6px 12px', fontSize: '1rem' }}>
-                מיין לפי נמען {sentSortAsc ? '▲' : '▼'}
-              </button>
-            </div>
-            <ul style={{ listStyle: 'none', padding: 0 }}>
-              {sentPrivateMessages
-                .filter(msg => {
-                  const name = (msg.receiver_name || msg.receiver_email || '').toLowerCase();
-                  return name.includes(sentFilter.toLowerCase());
-                })
-                .sort((a, b) => {
-                  const aName = (a.receiver_name || a.receiver_email || '').toLowerCase();
-                  const bName = (b.receiver_name || b.receiver_email || '').toLowerCase();
-                  if (aName < bName) return sentSortAsc ? -1 : 1;
-                  if (aName > bName) return sentSortAsc ? 1 : -1;
-                  return 0;
-                })
-                .map((msg, idx) => (
-                  <li key={msg.id || idx} className="card" style={{ marginBottom: 18 }}>
-                    <div className="class-name">ל: {msg.receiver_name || msg.receiver_email || msg.receiver_id}</div>
-                    <div style={{ color: 'var(--text-muted)', marginBottom: 4 }}>{msg.message_text}</div>
-                    <div style={{ fontSize: 12, color: 'var(--accent-color)' }}>{msg.sent_at ? new Date(msg.sent_at).toLocaleString('he-IL') : ''}</div>
-                  </li>
-                ))}
-            </ul>
-          </div>
-        )}
-      </div>
-    </div>
+            </Stack>
+          )}
+
+          {selectedTab === 'sent' && !loading && (
+            <Stack gap={4}>
+              <Heading size="md" color="brand.400">הודעות פרטיות שנשלחו</Heading>
+
+              <Flex gap={2} direction={{ base: 'column', md: 'row' }}>
+                <Input
+                  placeholder="סנן לפי שם/אימייל נמען..."
+                  value={sentFilter}
+                  onChange={(e) => setSentFilter(e.target.value)}
+                  bg="dark.bg"
+                  borderColor="dark.border"
+                />
+                <Button onClick={() => setSentSortAsc((v) => !v)} colorPalette="brand" variant="outline">
+                  מיין לפי נמען {sentSortAsc ? '▲' : '▼'}
+                </Button>
+              </Flex>
+
+              {filteredAndSortedSentMessages.map((msg, idx) => (
+                <Card.Root key={msg.id || idx} bg="dark.bg" borderColor="dark.border" borderWidth="1px">
+                  <Card.Body>
+                    <Text fontWeight="bold" mb={1}>ל: {msg.receiver_name || msg.receiver_email || msg.receiver_id}</Text>
+                    <Text color="gray.400" mb={1}>{msg.message_text}</Text>
+                    <Text fontSize="sm" color="brand.400">
+                      {msg.sent_at ? new Date(msg.sent_at).toLocaleString('he-IL') : ''}
+                    </Text>
+                  </Card.Body>
+                </Card.Root>
+              ))}
+            </Stack>
+          )}
+        </Card.Body>
+      </Card.Root>
+    </Container>
   );
 };
 


### PR DESCRIPTION
### Motivation
- Replace legacy CSS/markup with Chakra UI components for consistent styling and better UX in the pricing and messages pages.
- Improve trainee messaging usability by adding tabs, client-side filtering/sorting, and clearer loading/error states.
- Fix an import path casing issue for the trainer schedule page to avoid module resolution errors.

### Description
- Updated `App.jsx` to import `TrainerSchedulePage` from the corrected `./pages/Trainer/TrainerSchedulePage.jsx` path.
- Rewrote `PricingSection.jsx` to use Chakra UI primitives (`Box`, `Container`, `SimpleGrid`, `Button`, `Spinner`, etc.), removed the old CSS, added a spinner and friendly error text, kept API call via `apiService.get('/subscriptions/types')`, and preserved pricing/description rendering with improved layout and RTL support.
- Refactored `TraineeMessagesPage.jsx` to Chakra UI (`Container`, `Card`, `Stack`, `Spinner`, `Alert`, etc.), consolidated tab buttons, improved fetch error logging, added `useMemo`-backed filtering and sorting for sent messages, and removed the legacy CSS import.

### Testing
- Ran `npm run lint` on the frontend codebase and the lint checks passed.
- Ran the frontend unit tests with `npm test` and the existing test suite passed.
- Performed a local dev build/smoke start to verify the refactored pages render and API calls succeed in basic flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a94c29d9e88320ba0ff8d55c75860a)